### PR TITLE
fix: change the data structure of the ips output

### DIFF
--- a/module-metadata.json
+++ b/module-metadata.json
@@ -134,7 +134,7 @@
       "description": "The CRN of the endpoint gateway",
       "pos": {
         "filename": "outputs.tf",
-        "line": 6
+        "line": 7
       }
     },
     "vpe_ips": {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,7 @@
 output "vpe_ips" {
   description = "The endpoint gateway reserved ips"
-  value       = [for vpe_pg in ibm_is_virtual_endpoint_gateway.vpe : vpe_pg.ips]
+  value = { for vpe_pg in ibm_is_virtual_endpoint_gateway.vpe :
+  vpe_pg.name => vpe_pg.ips }
 }
 
 output "crn" {


### PR DESCRIPTION
### Description

Any insertion / deletion in list at https://github.com/terraform-ibm-modules/terraform-ibm-vpe-module/blob/f0ca43341640f18bfbf54431c84eaae0c039c704/variables.tf#L61C28-L61C28 results in the VPE IP changing for the services after the modification in the list.

This is problematic for consumers that have an expectation of IP stability. See whether we could come up with a data structure here that does not result in this issue - eg: a map.
Issue: https://github.com/terraform-ibm-modules/terraform-ibm-vpe-module/issues/343

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [x] Bug fix
- [ ] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content
Update to the data structure of the `vpe_ips` output. Added the gateway name as the key for each list of objects. This will help in differentiating the IPs for each gateways. For example:
 - Older versions: 
```
[
   [
       {
           address       = "10.10.10.5"
           id            = "xxxx-xxxxx-xxxxxx-xxxxx"
           name          = "sandbank-disports-sleeve-dugout"
           resource_type = "subnet_reserved_ip"
           subnet        = ""
        },
       {
           address       = "10.20.10.5"
           id            = "xxxx-xxxxx-xxxxxx-xxxxx"
           name          = "bannister-food-quarrel-concept"
           resource_type = "subnet_reserved_ip"
           subnet        = ""
        },
    ],
   [
       {
           address       = "10.10.10.4"
           id            = "xxxx-xxxxx-xxxxxx-xxxxx"
           name          = "haunt-tank-recital-princess"
           resource_type = "subnet_reserved_ip"
           subnet        = ""
        },
       {
           address       = "10.20.10.6"
           id            = "xxxx-xxxxx-xxxxxx-xxxxx"
           name          = "vigorous-tarantula-cash-reverse"
           resource_type = "subnet_reserved_ip"
           subnet        = ""
        },
    ],
]
```
- Newer versions:
```
{
    test-vpc-instance-account-management      = [
        {
            address       = "10.30.10.5"
            id            = "xxxx-xxxxx-xxxxxx-xxxxx"
            name          = "handwoven-poem-retention-mantis"
            resource_type = "subnet_reserved_ip"
            subnet        = ""
         },
        {
            address       = "10.10.10.12"
            id            = "xxxx-xxxxx-xxxxxx-xxxxx"
            name          = "smog-dastardly-bountiful-calf"
            resource_type = "subnet_reserved_ip"
            subnet        = ""
         },
     ]
    test-vpc-instance-billing                 = [
        {
            address       = "10.10.10.16"
            id            = "xxxx-xxxxx-xxxxxx-xxxxx"
            name          = "daffy-outfield-scrambled-showy"
            resource_type = "subnet_reserved_ip"
            subnet        = ""
         },
        {
            address       = "10.20.10.22"
            id            = "xxxx-xxxxx-xxxxxx-xxxxx"
            name          = "frogman-deflector-foe-deem"
            resource_type = "subnet_reserved_ip"
            subnet        = ""
         },
     ],
}
``` 
### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
