### PR TITLE
Fix VPE gateway details in output through datasource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ Brewfile.lock.json
 
 # Visual Studio Code
 .vscode/
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ No modules.
 | [ibm_is_subnet_reserved_ip.ip](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_subnet_reserved_ip) | resource |
 | [ibm_is_virtual_endpoint_gateway.vpe](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_virtual_endpoint_gateway) | resource |
 | [ibm_is_virtual_endpoint_gateway_ip.endpoint_gateway_ip](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_virtual_endpoint_gateway_ip) | resource |
+| [ibm_is_virtual_endpoint_gateway.vpe](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/is_virtual_endpoint_gateway) | data source |
 
 ### Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -133,3 +133,13 @@ resource "ibm_is_virtual_endpoint_gateway_ip" "endpoint_gateway_ip" {
 }
 
 ##############################################################################
+
+##############################################################################
+# Datasource to load endpoint gateways details once resources are fully created
+##############################################################################
+
+data "ibm_is_virtual_endpoint_gateway" "vpe" {
+  depends_on = [ibm_is_virtual_endpoint_gateway_ip.endpoint_gateway_ip]
+  count      = length(ibm_is_virtual_endpoint_gateway.vpe)
+  name       = ibm_is_virtual_endpoint_gateway.vpe[count.index].name
+}

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -202,6 +202,19 @@
       }
     }
   },
-  "data_resources": {},
+  "data_resources": {
+    "data.ibm_is_virtual_endpoint_gateway.vpe": {
+      "mode": "data",
+      "type": "ibm_is_virtual_endpoint_gateway",
+      "name": "vpe",
+      "provider": {
+        "name": "ibm"
+      },
+      "pos": {
+        "filename": "main.tf",
+        "line": 141
+      }
+    }
+  },
   "module_calls": {}
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "vpe_ips" {
   description = "The endpoint gateway reserved ips"
-  value = { for vpe_pg in ibm_is_virtual_endpoint_gateway.vpe :
+  value = { for vpe_pg in data.ibm_is_virtual_endpoint_gateway.vpe :
   vpe_pg.name => vpe_pg.ips }
 }
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -2,8 +2,11 @@
 package test
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
@@ -61,13 +64,69 @@ func setupOptions(t *testing.T, prefix string, dir string) *testhelper.TestOptio
 	return options
 }
 
+// ValidateOutputMapSliceContent takes a map of Terraform output keys and values and it expects that the
+// map contains a set of key => Slices couples
+// It checks that the input map has length > 0 and for each key the related Slice is not empty
+// If the value related to a key is not a slice it returns an error message
+// The function returns a list of the output keys whose Slice has length 0
+// and an error message that includes details about which keys were missing.
+// If the input map is empty it returns only the related error message
+func ValidateOutputMapOfSlicesContent(inputMap map[string]interface{}) ([]string, error) {
+	var failedKeys []string
+	var err error
+	// Set up ANSI escape codes for blue and bold text
+	blueBold := "\033[1;34m"
+	reset := "\033[0m"
+
+	// mapLen := len(inputMap)
+	// fmt.Println("Len of inputMap is ", mapLen)
+	if len(inputMap) == 0 {
+		err = fmt.Errorf("Output: %s'The input map has zero elements'%s\n", blueBold, reset)
+	} else {
+		// going through the inputMap keys
+		for k, v := range inputMap {
+			if reflect.TypeOf(v).String() == "[]interface {}" {
+				vArray := v.([]interface{})
+				if len(vArray) == 0 {
+					failedKeys = append(failedKeys, k)
+					err = fmt.Errorf("Output: The keys %s'%s'%s have empty slices\n", blueBold, failedKeys, reset)
+				}
+			} else {
+				failedKeys = append(failedKeys, k)
+				err = fmt.Errorf("Output: The key %s'%s'%s value is not a slice\n", blueBold, k, reset)
+				break
+			}
+		}
+	}
+
+	return failedKeys, err
+}
+
 func TestRunDefaultExample(t *testing.T) {
 	t.Parallel()
 
 	options := setupOptions(t, "vpe-default", defaultExampleTerraformDir)
+	options.SkipTestTearDown = true
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")
+	// checking vpe_ips to exist
+	outputs := terraform.OutputAll(options.Testing, options.TerraformOptions)
+	expectedOutputs := []string{"vpe_ips"}
+	_, outputErr := testhelper.ValidateTerraformOutputs(outputs, expectedOutputs...)
+	assert.NoErrorf(t, outputErr, "Some outputs not found or nil")
+	// checking vpe_ips to contain a set on not empty slices as expected
+	mapToValidate, ok := outputs["vpe_ips"].(map[string]interface{})
+	var outputErrMap error
+	if !ok {
+		outputErrMap = fmt.Errorf("Output: Failed to read value of key %s\n", "vpe_ips")
+	} else {
+		_, outputErrMap = ValidateOutputMapOfSlicesContent(mapToValidate)
+	}
+
+	assert.NoErrorf(t, outputErr, "Some outputs not found or nil")
+	assert.NoErrorf(t, outputErrMap, "Some outputs not having the expected structure")
+	options.TestTearDown()
 }
 
 func TestRunUpgradeExample(t *testing.T) {


### PR DESCRIPTION
### Description

This PR fixes the issue with the VPE gateway details returned in output: the fix is with using ibm_is_virtual_endpoint_gateway datasource to load the gateway details once all the resources are completely deployed instead of returning the ibm_is_virtual_endpoint_gateway resource details. 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fix issue with the VPE gateway details returned in output

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
