### PR TITLE
fix: fixed test bug on static gw name

### DIFF
--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,3 +1,11 @@
+### randomising the custom vpe names
+locals {
+  vpe_names = {
+    for k, v in var.vpe_names :
+    k => "${var.prefix}-${v}"
+  }
+}
+
 ##############################################################################
 # Resource Group
 ##############################################################################
@@ -93,7 +101,7 @@ module "vpes" {
   cloud_services       = var.cloud_services
   cloud_service_by_crn = local.cloud_service_by_crn
   service_endpoints    = var.service_endpoints
-  vpe_names            = var.vpe_names
+  vpe_names            = local.vpe_names
   #  See comments below (resource "time_sleep" "sleep_time") for explaination on why this is needed.
   depends_on = [time_sleep.sleep_time]
 }

--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -92,7 +92,7 @@ variable "service_endpoints" {
 }
 
 variable "vpe_names" {
-  description = "A Map to specify custom names for endpoint gateways whose keys are services and values are names to use for that service's endpoint gateway."
+  description = "A Map to specify custom names for endpoint gateways whose keys are services and values are names to use for that service's endpoint gateway. Each name will be prefixed with prefix value for isolated testing purposes."
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
### Description

Fixed default tests which now randomize the custom gateway(s) name (if set) to avoid stuck resources to fail tests

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
