### PR TITLE
fix: remove hyperb-postgres and hyperb-mongodb

### DIFF
--- a/examples/every-mt-vpe/main.tf
+++ b/examples/every-mt-vpe/main.tf
@@ -107,14 +107,6 @@ module "vpes" {
       service_name = "hs-crypto-tke"
     },
     {
-      service_name = "hyperp-dbaas-mongodb"
-      vpe_name     = "${var.prefix}-hyperp-mongodb"
-    },
-    {
-      service_name = "hyperp-dbaas-postgresql"
-      vpe_name     = "${var.prefix}-hyperp-postgresql"
-    },
-    {
       service_name = "iam-svcs"
     },
     {

--- a/examples/every-mt-vpe/variables.tf
+++ b/examples/every-mt-vpe/variables.tf
@@ -7,11 +7,13 @@ variable "ibmcloud_api_key" {
 variable "region" {
   description = "The region where VPC and services are deployed"
   type        = string
+  default     = "us-south"
 }
 
 variable "prefix" {
   description = "The prefix that you would like to append to your resources"
   type        = string
+  default     = "test"
 }
 
 variable "resource_group" {

--- a/examples/every-mt-vpe/variables.tf
+++ b/examples/every-mt-vpe/variables.tf
@@ -7,13 +7,11 @@ variable "ibmcloud_api_key" {
 variable "region" {
   description = "The region where VPC and services are deployed"
   type        = string
-  default     = "us-south"
 }
 
 variable "prefix" {
   description = "The prefix that you would like to append to your resources"
   type        = string
-  default     = "test"
 }
 
 variable "resource_group" {

--- a/service_endpoints.tf
+++ b/service_endpoints.tf
@@ -28,8 +28,6 @@ locals {
     hs-crypto-ep11-az3          = "crn:v1:bluemix:public:hs-crypto:${var.region}:::endpoint:ep11-az3.${local.endpoint_prefix}${var.region}.hs-crypto.cloud.ibm.com"
     hs-crypto-kmip              = "crn:v1:bluemix:public:hs-crypto:${var.region}:::endpoint:kmip.${local.endpoint_prefix}${var.region}.hs-crypto.cloud.ibm.com"
     hs-crypto-tke               = "crn:v1:bluemix:public:hs-crypto:${var.region}:::endpoint:tke.${local.endpoint_prefix}${var.region}.hs-crypto.cloud.ibm.com"
-    hyperp-dbaas-mongodb        = "crn:v1:bluemix:public:hyperp-dbaas-mongodb:${var.region}:::endpoint:dbaas900-mongodb.${local.endpoint_prefix}hyperp-dbaas.cloud.ibm.com"
-    hyperp-dbaas-postgresql     = "crn:v1:bluemix:public:hyperp-dbaas-postgresql:${var.region}:::endpoint:dbaas900-postgresql.${local.endpoint_prefix}hyperp-dbaas.cloud.ibm.com"
     iam-svcs                    = "crn:v1:bluemix:public:iam-svcs:global:::endpoint:${local.endpoint_prefix}iam.cloud.ibm.com"
     is                          = "crn:v1:bluemix:public:is:${var.region}:::endpoint:${var.region}.${local.endpoint_prefix}iaas.cloud.ibm.com"
     kms                         = "crn:v1:bluemix:public:kms:${var.region}:::endpoint:${local.endpoint_prefix}${var.region}.kms.cloud.ibm.com"

--- a/variables.tf
+++ b/variables.tf
@@ -92,8 +92,6 @@ variable "cloud_services" {
         "hs-crypto-ep11-az3",
         "hs-crypto-kmip",
         "hs-crypto-tke",
-        "hyperp-dbaas-mongodb",
-        "hyperp-dbaas-postgresql",
         "iam-svcs",
         "is",
         "kms",


### PR DESCRIPTION
### Description

tests are failing due to [end of life](https://www.ibm.com/blog/announcement/the-future-of-ibm-cloud-hyper-protect-dbaas/) for mongodb and postgres

````
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │ Error: [ERROR] Create Endpoint Gateway failed Service not found in global catalog
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │ {
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │     "StatusCode": 400,
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │     "Headers": {
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Allow-Snippet-Annotations": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "true"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Cache-Control": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "max-age=0, no-cache, no-store, must-revalidate"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Cf-Cache-Status": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "DYNAMIC"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Cf-Ray": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "8751b7d9dba63593-DFW"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Content-Length": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "292"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Content-Type": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "application/json"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Date": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "Tue, 16 Apr 2024 05:19:03 GMT"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Expires": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "-1"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Pragma": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "no-cache"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Server": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "cloudflare"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Strict-Transport-Security": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "max-age=31536000; includeSubDomains"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "Vary": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "Accept-Encoding"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "X-Content-Type-Options": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "nosniff"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "X-Request-Id": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "9c8a71dc-f27d-47ff-8f72-d7d496dd0496"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "X-Xss-Protection": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             "1; mode=block"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ]
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │     },
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │     "Result": {
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "errors": [
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             {
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │                 "code": "bad_field",
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │                 "message": "Service not found in global catalog",
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │                 "target": {
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │                     "name": "Crn",
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │                     "type": "field",
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │                     "value": "crn:v1:bluemix:public:hyperp-dbaas-mongodb:us-south:::endpoint:dbaas900-mongodb.private.hyperp-dbaas.cloud.ibm.com"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │                 }
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │             }
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         ],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │         "trace": "9c8a71dc-f27d-47ff-8f72-d7d496dd0496"
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │     },
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │     "RawResult": null
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │ }
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │ 
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │ 
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │   with module.vpes.ibm_is_virtual_endpoint_gateway.vpe["vpe-allmt-uuhfmw-hyperp-mongodb"],
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │   on ../../main.tf line 84, in resource "ibm_is_virtual_endpoint_gateway" "vpe":
TestRunEveryMultiTenantExample 2024-04-16T05:25:21Z logger.go:66: │   84: resource "ibm_is_virtual_endpoint_gateway" "vpe" {
````

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Remove hyper dba config due to service having end of life the end of March.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
