### PR TITLE
fix: extend sleep for postgres creation

### DIFF
--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -110,7 +110,7 @@ module "vpes" {
 # 2. Give time on deletion between the VPE destruction and the destruction of the SG that is attached to the VPE. This works around the error "Target not found"
 resource "time_sleep" "sleep_time" {
   depends_on       = [module.vpe_security_group.security_group_id, module.postgresql_db]
-  create_duration  = "120s"
+  create_duration  = "180s"
   destroy_duration = "120s"
 }
 


### PR DESCRIPTION
### Description

full logs at https://github.ibm.com/GoldenEye/issues/issues/11284

The error is:
````hcl
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [33m│[0m [0m[0m  with module.postgresql_db.ibm_database.postgresql_db,
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [33m│[0m [0m  on .terraform/modules/postgresql_db/main.tf line 55, in resource "ibm_database" "postgresql_db":
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [33m│[0m [0m  55: resource "ibm_database" "postgresql_db" [4m{[0m[0m
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [33m│[0m [0m
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [33m╵[0m[0m
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m╷[0m[0m
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m[1m[31mError: [0m[0m[1m[ERROR] Create Endpoint Gateway failed Could not find service
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m{
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m    "StatusCode": 400,
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m    "Headers": {
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Allow-Snippet-Annotations": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "true"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Cache-Control": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "max-age=0, no-cache, no-store, must-revalidate"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Cf-Cache-Status": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "DYNAMIC"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Cf-Ray": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "8da118a37c39ddaf-DFW"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Content-Length": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "115"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Content-Type": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "application/json; charset=utf-8"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Date": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "Tue, 29 Oct 2024 06:26:52 GMT"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Expires": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "-1"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Pragma": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "no-cache"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Server": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "cloudflare"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Strict-Transport-Security": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "max-age=31536000; includeSubDomains"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "Vary": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "Accept-Encoding"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "X-Content-Type-Options": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "nosniff"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "X-Request-Id": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "322f2076-a3dc-4624-b59e-2cabf29cc798"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "X-Xss-Protection": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            "1; mode=block"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ]
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m    },
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m    "Result": {
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "errors": [
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            {
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m                "code": "bad_field",
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m                "message": "Could not find service"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m            }
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        ],
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m        "trace": "322f2076-a3dc-4624-b59e-2cabf29cc798"
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m    },
TestRunAdvancedExample 2024-10-29T06:27:09Z logger.go:66: [31m│[0m [0m    "RawResult": null
````

I ran it locally and it passed. I have extended the sleep to 3 minutes and will monitor the next time our continuous tests run.
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
