### PR TITLE
fix: output not needed

### DIFF
--- a/examples/reserved-ips/outputs.tf
+++ b/examples/reserved-ips/outputs.tf
@@ -1,13 +1,7 @@
-output "vpe_ips" {
-  description = "The endpoint gateway reserved ips"
-  value       = module.vpes.vpe_ips
-}
-
 output "crn" {
   description = "The CRN of the endpoint gateway"
   value       = module.vpes.crn
 }
-
 
 output "reserved_ips" {
   description = "The map of reserved ips created in the example"


### PR DESCRIPTION
### Description

test failure due to `vpe_ips` not having any value. This is expected as we do not pass any `cloud_services` to the main module and instead create them using the standalone `ip` module.

````
TestRunReservedIpExample 2024-11-26T06:15:30Z command.go:100: Running command terraform with args [output -no-color -json]
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185: {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:   "crn": {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "sensitive": false,
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "type": [
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "tuple",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       []
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     ],
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "value": []
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:   },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:   "endpoint_ip_list": {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "sensitive": false,
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "type": [
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "list",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       [
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "map",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "string"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       ]
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     ],
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "value": [
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "ip_name": "res-ips-p7uwea-vpc-instance-subnet-a-cloud-object-storage-gateway-1-ip",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "name": "vpe-vpc-cloud-object-storage-1",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "subnet_id": "0717-bf2ad09c-1f5b-4c70-9edb-833003272d6b"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "ip_name": "res-ips-p7uwea-vpc-instance-subnet-a-kms-gateway-1-ip",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "name": "vpe-vpc-kms-1",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "subnet_id": "0717-bf2ad09c-1f5b-4c70-9edb-833003272d6b"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "ip_name": "res-ips-p7uwea-vpc-instance-subnet-b-cloud-object-storage-gateway-2-ip",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "name": "vpe-vpc-cloud-object-storage-2",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "subnet_id": "0727-39ad2ad6-fef9-4030-9c54-b2117b9a9a74"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "ip_name": "res-ips-p7uwea-vpc-instance-subnet-b-kms-gateway-2-ip",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "name": "vpe-vpc-kms-2",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "subnet_id": "0727-39ad2ad6-fef9-4030-9c54-b2117b9a9a74"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "ip_name": "res-ips-p7uwea-vpc-instance-subnet-c-cloud-object-storage-gateway-3-ip",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "name": "vpe-vpc-cloud-object-storage-3",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "subnet_id": "0737-016f753f-bd43-4fec-9161-fefcf85185df"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "ip_name": "res-ips-p7uwea-vpc-instance-subnet-c-kms-gateway-3-ip",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "name": "vpe-vpc-kms-3",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "subnet_id": "0737-016f753f-bd43-4fec-9161-fefcf85185df"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       }
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     ]
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:   },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:   "reserved_ips": {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "sensitive": false,
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "type": [
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "object",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "vpe-vpc-cloud-object-storage-1": "string",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "vpe-vpc-cloud-object-storage-2": "string",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "vpe-vpc-cloud-object-storage-3": "string",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "vpe-vpc-kms-1": "string",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "vpe-vpc-kms-2": "string",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "vpe-vpc-kms-3": "string"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       }
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     ],
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "value": {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "vpe-vpc-cloud-object-storage-1": "0717-71ee4fdc-2809-48fe-8b4d-3222f3384b19",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "vpe-vpc-cloud-object-storage-2": "0727-28882e6b-743c-4d73-b065-8662e5cf7c77",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "vpe-vpc-cloud-object-storage-3": "0737-3315f8da-7194-4b5b-94d3-c188161067c8",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "vpe-vpc-kms-1": "0717-9031bd5b-72cf-44e1-836d-c603bc2ab11f",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "vpe-vpc-kms-2": "0727-b97205ec-4015-44b4-818b-8d8a5db07410",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "vpe-vpc-kms-3": "0737-2e994e2e-2f5b-499a-8b51-b1cfd7e84342"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     }
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:   },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:   "subnet_zone_list": {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "sensitive": false,
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "type": [
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "list",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       [
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "map",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "string"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       ]
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     ],
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "value": [
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "cidr": "10.10.10.0/24",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "crn": "crn:v1:bluemix:public:is:us-south-1:a/abac0df06b644a9cabc6e44f55b3880e::subnet:0717-bf2ad09c-1f5b-4c70-9edb-833003272d6b",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "id": "0717-bf2ad09c-1f5b-4c70-9edb-833003272d6b",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "name": "res-ips-p7uwea-vpc-instance-subnet-a",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "zone": "us-south-1"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "cidr": "10.20.10.0/24",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "crn": "crn:v1:bluemix:public:is:us-south-2:a/abac0df06b644a9cabc6e44f55b3880e::subnet:0727-39ad2ad6-fef9-4030-9c54-b2117b9a9a74",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "id": "0727-39ad2ad6-fef9-4030-9c54-b2117b9a9a74",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "name": "res-ips-p7uwea-vpc-instance-subnet-b",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "zone": "us-south-2"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "cidr": "10.30.10.0/24",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "crn": "crn:v1:bluemix:public:is:us-south-3:a/abac0df06b644a9cabc6e44f55b3880e::subnet:0737-016f753f-bd43-4fec-9161-fefcf85185df",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "id": "0737-016f753f-bd43-4fec-9161-fefcf85185df",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "name": "res-ips-p7uwea-vpc-instance-subnet-c",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:         "zone": "us-south-3"
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       }
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     ]
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:   },
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:   "vpe_ips": {
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "sensitive": false,
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "type": [
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       "object",
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:       {}
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     ],
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:     "value": {}
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185:   }
TestRunReservedIpExample 2024-11-26T06:15:31Z command.go:185: }
=== NAME  TestRunReservedIpExample
    other_test.go:38: 
        	Error Trace:	/mnt/terraform-ibm-vpe-gateway/tests/other_test.go:38
        	Error:      	Received unexpected error:
        	            	Output: [1;34m'The input map has zero elements'[0m
        	Test:       	TestRunReservedIpExample
        	Messages:   	Some outputs not having the expected structure
TestRunReservedIpExample 2024-11-26T06:15:31Z retry.go:91: terraform [output -no-color -json]
Terratest failed. Debug the Test and delete resources manually.
--- FAIL: TestRunReservedIpExample (192.53s)
````

https://github.ibm.com/GoldenEye/issues/issues/11757

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
