### PR TITLE
fix: vpe tests

### DIFF
--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -25,13 +25,10 @@ func TestRunReservedIpExample(t *testing.T) {
 	expectedOutputs := []string{"reserved_ips"}
 	_, outputErr := testhelper.ValidateTerraformOutputs(outputs, expectedOutputs...)
 	assert.NoErrorf(t, outputErr, "Some outputs not found or nil")
-	// checking reserved_ips to contain a set on not empty slices as expected
-	mapToValidate, ok := outputs["reserved_ips"].(map[string]interface{})
+	_, ok := outputs["reserved_ips"].(map[string]interface{})
 	var outputErrMap error
 	if !ok {
 		outputErrMap = fmt.Errorf("Output: Failed to read value of key %s\n", "reserved_ips")
-	} else {
-		_, outputErrMap = ValidateOutputMapOfSlicesContent(mapToValidate)
 	}
 
 	assert.NoErrorf(t, outputErr, "Some outputs not found or nil")


### PR DESCRIPTION
### Description

fix test failure:

````
=== NAME  TestRunReservedIpExample
    other_test.go:38: 
        	Error Trace:	/mnt/terraform-ibm-vpe-gateway/tests/other_test.go:38
        	Error:      	Received unexpected error:
        	            	Output: The key [1;34m'vpe-vpc-cloud-object-storage-2'[0m value is not a slice
        	Test:       	TestRunReservedIpExample
        	Messages:   	Some outputs not having the expected structure
````

is an object and not a slice

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
