### PR TITLE
fix: bump ICD pg to 4.1.3 and override deletion protection

### DIFF
--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -64,11 +64,12 @@ module "vpe_security_group" {
 ##############################################################################
 
 module "postgresql_db" {
-  source            = "terraform-ibm-modules/icd-postgresql/ibm"
-  version           = "4.0.1"
-  resource_group_id = module.resource_group.resource_group_id
-  name              = "${var.prefix}-vpe-pg"
-  region            = var.region
+  source              = "terraform-ibm-modules/icd-postgresql/ibm"
+  version             = "4.1.3"
+  resource_group_id   = module.resource_group.resource_group_id
+  name                = "${var.prefix}-vpe-pg"
+  region              = var.region
+  deletion_protection = false
 }
 
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -169,7 +169,8 @@ func TestRunBasicExample(t *testing.T) {
 func getFullConfigSolutionTestVariables(mainOptions *testschematic.TestSchematicOptions, existingOptions *testhelper.TestOptions) []testschematic.TestSchematicTerraformVar {
 	// try to cover some variety of use cases
 	testCloudSvcList := []map[string]any{
-		{"service_name": "is"},
+		// Avoid is until https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6224 is reolved
+		// {"service_name": "is"},
 		{"service_name": "kms", "allow_dns_resolution_binding": true},
 		{"service_name": "cloud-object-storage", "vpe_name": mainOptions.Prefix + "-cos"},
 	}

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -169,8 +169,7 @@ func TestRunBasicExample(t *testing.T) {
 func getFullConfigSolutionTestVariables(mainOptions *testschematic.TestSchematicOptions, existingOptions *testhelper.TestOptions) []testschematic.TestSchematicTerraformVar {
 	// try to cover some variety of use cases
 	testCloudSvcList := []map[string]any{
-		// Avoid is until https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6224 is reolved
-		// {"service_name": "is"},
+		{"service_name": "is"},
 		{"service_name": "kms", "allow_dns_resolution_binding": true},
 		{"service_name": "cloud-object-storage", "vpe_name": mainOptions.Prefix + "-cos"},
 	}


### PR DESCRIPTION
### Description

The postgresql module consumed by the tests in this module introduced support for deletion protection. The test needs to set this to false, so that the database instance can be destroyed during cleanup.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This is an update to tests, not the module, so no release is necessary.

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
