### PR TITLE
fix(deps): bump provider to 1.81.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.79.2, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.81.1, <2.0.0 |
 
 ### Modules
 

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -10,7 +10,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # pin above lowest vesion, required for postgresql and IAM auth policy
-      version = ">=1.79.2"
+      version = ">=1.81.1"
     }
     time = {
       source  = "hashicorp/time"

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -10,7 +10,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # pin to lowest vesion, required for IAM auth policy
-      version = "1.79.2"
+      version = "1.81.1"
     }
   }
 }

--- a/examples/every-multi-tenant-svc/versions.tf
+++ b/examples/every-multi-tenant-svc/versions.tf
@@ -10,7 +10,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # pin to lowest vesion, required for IAM auth policy
-      version = "1.79.2"
+      version = "1.81.1"
     }
   }
 }

--- a/modules/reserved-ips/README.md
+++ b/modules/reserved-ips/README.md
@@ -94,7 +94,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.79.2, <2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.81.1, <2.0.0 |
 
 ### Modules
 

--- a/modules/reserved-ips/versions.tf
+++ b/modules/reserved-ips/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.79.2, <2.0.0"
+      version = ">= 1.81.1, <2.0.0"
     }
   }
 }

--- a/solutions/fully-configurable/versions.tf
+++ b/solutions/fully-configurable/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.80.2"
+      version = "1.81.1"
     }
   }
 }

--- a/tests/existing-resources/versions.tf
+++ b/tests/existing-resources/versions.tf
@@ -10,7 +10,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # pin to lowest vesion, required for IAM auth policy
-      version = "1.79.2"
+      version = "1.81.1"
     }
   }
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -169,8 +169,7 @@ func TestRunBasicExample(t *testing.T) {
 func getFullConfigSolutionTestVariables(mainOptions *testschematic.TestSchematicOptions, existingOptions *testhelper.TestOptions) []testschematic.TestSchematicTerraformVar {
 	// try to cover some variety of use cases
 	testCloudSvcList := []map[string]any{
-		// Avoid is until https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6224 is reolved
-		// {"service_name": "is"},
+		{"service_name": "is"},
 		{"service_name": "kms", "allow_dns_resolution_binding": true},
 		{"service_name": "cloud-object-storage", "vpe_name": mainOptions.Prefix + "-cos"},
 	}

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">=1.79.2, <2.0.0"
+      version = ">=1.81.1, <2.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description

Bump provider to 1.81.1 to resolve issue with [multiple VPE gateways in parallel](https://github.com/IBM-Cloud/terraform-provider-ibm/issues/6224)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
